### PR TITLE
Feature/9 optional descriptive keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-06-28
+
+### Added
+
+- Documentation about integration tests in `test/README.md` and `test/resources/README.md`
+
+### Changed
+
+- When updating clusters, descriptive keys of the initial clusters are now an optional parameter. This allows the reuse of existing clusters, even when they contain overlapping elements ([9](https://github.com/kbrbe/work-set-clustering/issues/9))
+- Integration tests are restructured: instead of a single TestClustering class with test functions, we have now different "sets" of test functions (test functions grouped in a class). Actual test cases can inherit the test function classes that are appropriate for the given context
+
 ## [0.3.0] - 2024-02-21
 
 Breaking changes for use as a programming library, because the parameter for the input file expects now a list.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   given-names: "Sven"
   orcid: "https://orcid.org/0000-0002-7304-3787"
 title: "Work-set clustering"
-version: 0.3.0
+version: 0.4.0
 doi: 10.5281/zenodo.10011417
-date-released: 2024-02-21
+date-released: 2024-06-28
 url: "https://github.com/kbrbe/work-set-clustering"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can find more examples of cluster input in the `test/resources` directory.
 ### Reuse existing clusters
 
 You can reuse the clusters created from an earlier run,
-but you also have to provide the mapping between the previous elements and their descriptive keys.
+but you also have to provide the mapping between the previous elements and optionally their descriptive keys.
 
 
 ```python
@@ -99,6 +99,9 @@ Please note that with the two parameters `--existing-clusters` and `--existing-c
 the data from a previous run are provided.
 
 Similar to the initial clustering, you can provide several input files.
+
+> [!NOTE]
+> When skipping existing descriptive keys, existing cluster identifiers and assigments are kept, even if their elements have overlapping descriptive keys. Additionally, none of the new elements can be mapped to the existing clusters, because no descriptive keys are provided (more info in https://github.com/kbrbe/work-set-clustering/issues/9)
 
 ## Usage as a library
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setuptools.setup(
     name = "work_set_clustering",
-    version = "0.3.0",
+    version = "0.4.0",
     url = "https://github.com/kbrbe/work-set-clustering",
     author = "Sven Lieber",
     author_email = "Sven.Lieber@kbr.be",

--- a/test/README.md
+++ b/test/README.md
@@ -10,6 +10,7 @@ Reusable test cases grouped in classes are defined in the file `test_cases.py`
 * InitialElementsTogether
 * UpdateClusteringSize
 * UpdateClusteringElementsTogether
+* UpdateClusteringSizeReusing
 
 
 ## Test cases
@@ -22,9 +23,8 @@ Initial clustering with a single descriptive key file (`cluster-input-1.csv`)
 ### TestUpdateClusteringSingleInput
 Update of clustering with `cluster-input-2.csv`
 
-
-### TestClusterMultipleInput
-Initial clustering with multiple descriptive key files (`cluster-input-1.1.csv`, `cluster-input-1.2.csv`) + update of clustering with `cluster-input-2.csv`
+### TestClusteringMultipleInput
+Initial clustering with multiple descriptive key files (`cluster-input-1.1.csv`, `cluster-input-1.2.csv`)
 
 ### TestClusterOverlappingKeysDifferentClusters
 Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv`

--- a/test/README.md
+++ b/test/README.md
@@ -3,13 +3,31 @@
 > [!NOTE]
 > For an explanation of test data, please consult the README file in the directory `resources`.
 
+## Reusable test case functions
 Reusable test cases grouped in classes are defined in the file `test_cases.py`
 
-* TestClustering: this class contains all test cases
+* InitialClusteringSize
+* InitialElementsTogether
+* UpdateClusteringSize
+* UpdateClusteringElementsTogether
 
+
+## Test cases
 The following test cases exist in the file `test_clustering.py`
+Each test case reuses actual test functions via inheritance from test case functions in `test_cases.py` (see above) and/or defines their own additional test cases
 
-* TestClusteringSingleInput: Initial clustering with a single descriptive key file (`cluster-input-1.csv`) + update of clustering with `cluster-input-2.csv`
-* TestClusterMultipleInput: Initial clustering with multiple descriptive key files (`cluster-input-1.1.csv`, `cluster-input-1.2.csv`) + update of clustering with `cluster-input-2.csv`
-* TestClusterOverlappingKeysDifferentClusters: Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv`
-* TestClusterOverlappingKeysDifferentClustersReusingKeys: Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv` by also reusing descriptive keys `cluster-input-1.csv`
+### TestClusteringSingleInput
+Initial clustering with a single descriptive key file (`cluster-input-1.csv`)
+
+### TestUpdateClusteringSingleInput
+Update of clustering with `cluster-input-2.csv`
+
+
+### TestClusterMultipleInput
+Initial clustering with multiple descriptive key files (`cluster-input-1.1.csv`, `cluster-input-1.2.csv`) + update of clustering with `cluster-input-2.csv`
+
+### TestClusterOverlappingKeysDifferentClusters
+Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv`
+
+### TestClusterOverlappingKeysDifferentClustersReusingKeys
+Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv` by also reusing descriptive keys `cluster-input-1.csv`

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,15 @@
+# Explanation of test cases
+
+> [!NOTE]
+> For an explanation of test data, please consult the README file in the directory `resources`.
+
+Reusable test cases grouped in classes are defined in the file `test_cases.py`
+
+* TestClustering: this class contains all test cases
+
+The following test cases exist in the file `test_clustering.py`
+
+* TestClusteringSingleInput: Initial clustering with a single descriptive key file (`cluster-input-1.csv`) + update of clustering with `cluster-input-2.csv`
+* TestClusterMultipleInput: Initial clustering with multiple descriptive key files (`cluster-input-1.1.csv`, `cluster-input-1.2.csv`) + update of clustering with `cluster-input-2.csv`
+* TestClusterOverlappingKeysDifferentClusters: Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv`
+* TestClusterOverlappingKeysDifferentClustersReusingKeys: Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv` by also reusing descriptive keys `cluster-input-1.csv`

--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,7 @@ Reusable test cases grouped in classes are defined in the file `test_cases.py`
 * UpdateClusteringSize
 * UpdateClusteringElementsTogether
 * UpdateClusteringSizeReusing
+* UpdateClusteringNotReusingKeysElementsTogether
 
 
 ## Test cases
@@ -31,3 +32,4 @@ Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv`
 
 ### TestClusterOverlappingKeysDifferentClustersReusingKeys
 Update of clusters `clusters-1-overlap.csv` with `cluster-input-2.csv` by also reusing descriptive keys `cluster-input-1.csv`
+

--- a/test/resources/README.md
+++ b/test/resources/README.md
@@ -13,7 +13,7 @@ and `e7` will form its own cluster with a single element `(e7)`, because it does
 When for an update we consider the file `clusters-1.csv` (representing a correct clustering of the first input) with the following clusters and identifiers `c1: (e1, e2)` and `c2: (e3, e4)`
 we expect that the mentioned cluster identifiers `c1` and `c2` are reused.
 
-# Different clusters based on human judgement, despite overlapping descriptive keys
+## Different clusters based on human judgement, despite overlapping descriptive keys
 
 However, we also want to test what happens if due to a human assignment, elements are clustered differently despite of overlapping descriptive keys (https://github.com/kbrbe/work-set-clustering/issues/9)
 

--- a/test/resources/README.md
+++ b/test/resources/README.md
@@ -1,0 +1,23 @@
+# Explanation of test data
+
+* For an initial clustering we have the elements `e1, e2, e3, e4` and their descriptive keys in the file `cluster-input-1.csv`
+* For an update of clusters we have the new elements `e5, e6, e7` and their descriptive keys in the file `cluster-input-2.csv`
+
+Initially, `e1` and `e2`  share at least one descriptive key as well as `e3` and `e4`.
+Hence there will be two clusters with random unique identifiers: `(e1, e2)`  and `(e3, e4)`
+
+When considering the second file to update the clusters, `e5` will be merged with `(e1, e2)` due to an overlapping descriptive key,
+`e6` will be merged with `(e3, e4)` due to an overlapping descriptive key,
+and `e7` will form its own cluster with a single element `(e7)`, because it does not share a descriptive key with any other element.
+
+When for an update we consider the file `clusters-1.csv` (representing a correct clustering of the first input) with the following clusters and identifiers `c1: (e1, e2)` and `c2: (e3, e4)`
+we expect that the mentioned cluster identifiers `c1` and `c2` are reused.
+
+# Different clusters based on human judgement, despite overlapping descriptive keys
+
+However, we also want to test what happens if due to a human assignment, elements are clustered differently despite of overlapping descriptive keys (https://github.com/kbrbe/work-set-clustering/issues/9)
+
+Therefore we use the file `clusters-1-overlap.csv` where we get the clusters `c1: (e1, e2)`, `c2: (e3)` and `c3: (e4)`.
+
+Please note that `e3` and `e4` still share descriptive keys according to the file `cluster-input-1.csv`.
+Whether or not we reuse the existing keys will influence the outcome.

--- a/test/resources/README.md
+++ b/test/resources/README.md
@@ -21,3 +21,6 @@ Therefore we use the file `clusters-1-overlap.csv` where we get the clusters `c1
 
 Please note that `e3` and `e4` still share descriptive keys according to the file `cluster-input-1.csv`.
 Whether or not we reuse the existing keys will influence the outcome.
+
+* When reusing descriptive keys we should get the clusters as usual `c1: (e1, e2)`, `(e3, e4, e6)`, `(e7)`. Please not that neither the cluster identifier `c2` nor `c3` are reused, since their members end up in the same cluster which will get a new random identifier
+* When not reusing the keys we should get the clusters `c1: (e1, e2)`, `c2: (e3)`, `c3: (e4)`, `(e5)`, `(e6)`, `(e7)`

--- a/test/resources/clusters-1-overlap.csv
+++ b/test/resources/clusters-1-overlap.csv
@@ -1,0 +1,5 @@
+"elementID","clusterID"
+"e1","c1"
+"e2","c1"
+"e3","c2"
+"e4","c3"

--- a/test/test_cases.py
+++ b/test/test_cases.py
@@ -1,0 +1,84 @@
+import unittest
+import csv
+
+# -----------------------------------------------------------------------------
+class InitialClusteringSize():
+  """A class with integration tests covering the number of clusters for the initial clustering"""
+
+  # ---------------------------------------------------------------------------
+  def testCorrectNumberOfClusters(self):
+    """With given cluster input, two clusters should be found"""
+    numberFoundClusters = len(self.getInitialClusterData()['clusterIdentifiers'])
+    numberExpectedClusters = 2
+    self.assertEqual(numberFoundClusters, numberExpectedClusters, msg=f'Found {numberFoundClusters} clusters instead of {numberExpectedClusters}')
+
+# -----------------------------------------------------------------------------
+class UpdateClusteringSize():
+  """A class with integration tests covering the number of clusters for the initial clustering"""
+
+  # ---------------------------------------------------------------------------
+  def testCorrectNumberOfClusters(self):
+    """With given cluster input, three clusters should be found"""
+    numberFoundClusters = len(self.getUpdatedClusterData()['clusterIdentifiers'])
+    numberExpectedClusters = 3
+    self.assertEqual(numberFoundClusters, numberExpectedClusters, msg=f'Found {numberFoundClusters} clusters instead of {numberExpectedClusters}')
+
+
+# -----------------------------------------------------------------------------
+class InitialElementsTogether():
+  """A class with integration test cases in case only the initial clustering is performed."""
+
+  # ---------------------------------------------------------------------------
+  def testElement1And2Together(self):
+    """Element e1 and e2 should be clustered together"""
+    clusterE1 = self.getInitialClusterData()['elementToCluster']['e1']
+    clusterE2 = self.getInitialClusterData()['elementToCluster']['e2']
+    self.assertEqual(clusterE1, clusterE2, msg=f'Different clusters for e1 and e2 ({clusterE1} != {clusterE2})')
+
+  # ---------------------------------------------------------------------------
+  def testElement3And4Together(self):
+    """Element e3 and e4 should be clustered together"""
+    clusterE3 = self.getInitialClusterData()['elementToCluster']['e3']
+    clusterE4 = self.getInitialClusterData()['elementToCluster']['e4']
+    self.assertEqual(clusterE3, clusterE4, msg=f'Different clusters for e3 and e4 ({clusterE3} != {clusterE4})')
+
+# -----------------------------------------------------------------------------
+class UpdateClusteringElementsTogether():
+  """A class with integration test cases for updated clusters."""
+
+  # ---------------------------------------------------------------------------
+  def testElement1And5Together(self):
+    """New element e5 should be clustered together with the initial e1 and e2"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e1']
+    clusterNew = self.getUpdatedClusterData()['elementToCluster']['e5']
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Different clusters for initial e1 and updated e5 ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement1SameClusterIDAfterUpdate(self):
+    """Element e1 should have the same clusterID after update when e5 was added"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e1']
+    clusterNew = "c1"
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Initial cluster of e1 has changed after update ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement5SameClusterIDAfterUpdate(self):
+    """Element e5 should be in the same clusterID as the initial e1"""
+    clusterID = self.getUpdatedClusterData()['elementToCluster']['e5']
+    clusterExpected = "c1"
+    self.assertEqual(clusterID, clusterExpected, msg=f'Element e5 was not added to the existing clusterID of e1 ({clusterID} != {clusterExpected})')
+
+  # ---------------------------------------------------------------------------
+  def testElement2And5Together(self):
+    """Element e5 should be clustered together with the initial e1 and e2"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e2']
+    clusterNew = self.getUpdatedClusterData()['elementToCluster']['e5']
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Different clusters for initial e2 and updated e5 ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement7InNewCluster(self):
+    """Element e7 should be clustered in a new cluster (no overlap with initial clusters)"""
+    clusterOfE7 = self.getUpdatedClusterData()['elementToCluster']['e7']
+    elementsOfCluster = self.getUpdatedClusterData()['clusterToElement'][clusterOfE7]
+    self.assertEqual(len(elementsOfCluster), 1, msg=f'Other elements in the cluster of e7: {elementsOfCluster}')
+
+

--- a/test/test_cases.py
+++ b/test/test_cases.py
@@ -81,4 +81,88 @@ class UpdateClusteringElementsTogether():
     elementsOfCluster = self.getUpdatedClusterData()['clusterToElement'][clusterOfE7]
     self.assertEqual(len(elementsOfCluster), 1, msg=f'Other elements in the cluster of e7: {elementsOfCluster}')
 
+# -----------------------------------------------------------------------------
+class UpdateClusteringNotReusingKeysElementsTogether():
+  """A class with integration test cases for updated clusters when descriptive keys are not reused and no new elements can be added to existing clusters via keys."""
+
+  # ---------------------------------------------------------------------------
+  def testElement1And2Together(self):
+    """Elements e1 and e2 are in one cluster according to the user"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e1']
+    clusterNew = self.getUpdatedClusterData()['elementToCluster']['e2']
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Different clusters for e1 and e2 ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement3Alone(self):
+    """Element e3 should have its own cluster, even though there is an overlap via descriptive keys with e4"""
+    clusterElements = self.getUpdatedClusterData()['clusterToElement']['c2']
+    expectedNumber = 1
+    self.assertEqual(len(clusterElements), expectedNumber, msg=f'Element e3 is not alone in its cluster {clusterElements}')
+
+  # ---------------------------------------------------------------------------
+  def testElement3InC2(self):
+    """Element e3 should be in the cluster with identifier c3"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e3']
+    clusterNew = "c2"
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Cluster of e3 is not {clusterNew} ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement4Alone(self):
+    """Element e4 should have its own cluster, even though there is an overlap via descriptive keys with e4"""
+    clusterElements = self.getUpdatedClusterData()['clusterToElement']['c3']
+    expectedNumber = 1
+    self.assertEqual(len(clusterElements), expectedNumber, msg=f'Element e4 is not alone in its cluster {clusterElements}')
+
+  # ---------------------------------------------------------------------------
+  def testElement4InC3(self):
+    """Element e4 should be in the cluster with identifier c3"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e4']
+    clusterNew = "c3"
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Cluster of e4 is not {clusterNew} ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement5Alone(self):
+    """New element e5 should have its own cluster, even though there is an overlap via descriptive keys with existing elements"""
+    data = self.getUpdatedClusterData()
+    clusterElements = data['clusterToElement'][data['elementToCluster']['e5']]
+    expectedNumber = 1
+    self.assertEqual(len(clusterElements), expectedNumber, msg=f'Element e4 is not alone in its cluster {clusterElements}')
+
+  # ---------------------------------------------------------------------------
+  def testElement5InRandomClusterID(self):
+    """Element e5 should be in the cluster with a new random identifier"""
+    clusterID = self.getUpdatedClusterData()['elementToCluster']['e5']
+    knownClusterIDs = ['c1', 'c2', 'c3']
+    self.assertTrue(clusterID not in knownClusterIDs, msg=f'Cluster of e5 should have a new random ID, but it is an existing clusterID ({clusterID})')
+
+  # ---------------------------------------------------------------------------
+  def testElement6Alone(self):
+    """New element e6 should have its own cluster, even though there is an overlap via descriptive keys with existing elements"""
+    data = self.getUpdatedClusterData()
+    clusterElements = data['clusterToElement'][data['elementToCluster']['e6']]
+    expectedNumber = 1
+    self.assertEqual(len(clusterElements), expectedNumber, msg=f'Element e6 is not alone in its cluster {clusterElements}')
+
+  # ---------------------------------------------------------------------------
+  def testElement6InRandomClusterID(self):
+    """Element e6 should be in the cluster with a new random identifier"""
+    clusterID = self.getUpdatedClusterData()['elementToCluster']['e6']
+    knownClusterIDs = ['c1', 'c2', 'c3']
+    self.assertTrue(clusterID not in knownClusterIDs, msg=f'Cluster of e6 should have a new random ID, but it is an existing clusterID ({clusterID})')
+
+  # ---------------------------------------------------------------------------
+  def testElement7Alone(self):
+    """New element e7 should have its own cluster, even though there is an overlap via descriptive keys with existing elements"""
+    data = self.getUpdatedClusterData()
+    clusterElements = data['clusterToElement'][data['elementToCluster']['e7']]
+    expectedNumber = 1
+    self.assertEqual(len(clusterElements), expectedNumber, msg=f'Element e7 is not alone in its cluster {clusterElements}')
+
+  # ---------------------------------------------------------------------------
+  def testElement7InRandomClusterID(self):
+    """Element e7 should be in the cluster with a new random identifier"""
+    clusterID = self.getUpdatedClusterData()['elementToCluster']['e7']
+    knownClusterIDs = ['c1', 'c2', 'c3']
+    self.assertTrue(clusterID not in knownClusterIDs, msg=f'Cluster of e7 should have a new random ID, but it is an existing clusterID ({clusterID})')
+
 

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -67,6 +67,20 @@ class TestClustering():
     self.assertEqual(clusterInitial, clusterNew, msg=f'Different clusters for initial e1 and updated e5 ({clusterInitial} != {clusterNew})')
 
   # ---------------------------------------------------------------------------
+  def testElement1SameClusterAfterUpdate(self):
+    """Element e1 should have the same clusterID after update when e5 was added"""
+    clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e1']
+    clusterNew = "c1"
+    self.assertEqual(clusterInitial, clusterNew, msg=f'Initial cluster of e1 has changed after update ({clusterInitial} != {clusterNew})')
+
+  # ---------------------------------------------------------------------------
+  def testElement5SameClusterAfterUpdate(self):
+    """Element e5 should be in the same clusterID as the initial e1"""
+    clusterID = self.getUpdatedClusterData()['elementToCluster']['e5']
+    clusterExpected = "c1"
+    self.assertEqual(clusterID, clusterExpected, msg=f'Element e5 was not added to the existing clusterID of e1 ({clusterID} != {clusterExpected})')
+
+  # ---------------------------------------------------------------------------
   def testElement2And5Together(self):
     """Element e5 should be clustered together with the initial e1 and e2"""
     clusterInitial = self.getUpdatedClusterData()['elementToCluster']['e2']


### PR DESCRIPTION
* Making the parameter for descriptive keys of existing clusters optional. This enables the reuse of clusters and cluster identifiers even for clusters whose elements have overlapping descriptive keys (see https://github.com/kbrbe/work-set-clustering/issues/9)